### PR TITLE
Add interval bandwidth reporting option

### DIFF
--- a/include/options.h
+++ b/include/options.h
@@ -34,6 +34,7 @@ struct options {
 	char *urls[MAX_URLS];
 	size_t urls_l;
 	char *urls_loc;
+        double worker_report_interval; 
 };
 
 int initialise_options(struct options *opt, int argc, char **argv);

--- a/src/getter.c
+++ b/src/getter.c
@@ -56,7 +56,7 @@ int get_once(struct worker *workers, struct options* opt, int *requests)
         struct timeval now_tv;
         int dl_delta = 0;
         double last_report = 0, now = 0, speed = 0, time_delta = 0;
-        unsigned int report_bytes_dl = 0, report_count = 0;
+        unsigned int report_bytes_dl = 0;
 
 	for(w = workers; w; w = w->next) {
 		msg_write(w->pipe_w, "RESET", sizeof("RESET"));
@@ -116,11 +116,14 @@ int get_once(struct worker *workers, struct options* opt, int *requests)
                                          now = now_tv.tv_sec + now_tv.tv_usec / 1000000.0;
                                          time_delta = now - last_report;
                                          if(time_delta >= opt->worker_report_interval) {
-                                           speed = report_bytes_dl / time_delta;
-                                           fprintf(stderr, "GETTER_INTERIM_RESULT[%u]=%f\r\n", report_count, speed); 
-                                           fprintf(stderr, "GETTER_INTERVAL[%u]=%f\r\n", report_count, time_delta);
-                                           fprintf(stderr, "GETTER_ENDING[%u]=%f\r\n", report_count, now);
-                                           report_count++;
+                                           speed = 8 * report_bytes_dl / time_delta; //Report on bits not bytes
+                                           fprintf(stdout, "Worker %u: %f bps (%u bytes over %f seconds) ending at %f\r\n", 
+                                                           w->pipe_w,
+                                                           speed,
+                                                           report_bytes_dl,
+                                                           time_delta,
+                                                           now);
+
                                            report_bytes_dl = 0;
                                            last_report = now;
                                          }

--- a/src/options.c
+++ b/src/options.c
@@ -29,6 +29,7 @@ int initialise_options(struct options *opt, int argc, char **argv)
 	opt->urls_l = 0;
 	memset(&opt->urls, 0, MAX_URLS * sizeof(&opt->urls));
 	opt->urls_loc = NULL;
+        opt->worker_report_interval = 0;
 
 	if(parse_options(opt, argc, argv) < 0)
 		return -2;
@@ -51,7 +52,7 @@ void destroy_options(struct options *opt)
 
 static void usage(const char *name)
 {
-	fprintf(stderr, "Usage: %s [-46Dh] [-c <count>] [-d <dns_servers>] [-i <interval>] [-l <length>] [-n <workers>] [-o <output>] [-t <timeout>] [url_file]\n", name);
+	fprintf(stderr, "Usage: %s [-46Dh] [-c <count>] [-d <dns_servers>] [-i <interval>] [-l <length>] [-n <workers>] [-o <output>] [-t <timeout>] [-r <report_interval>] [url_file]\n", name);
 }
 
 
@@ -59,12 +60,13 @@ int parse_options(struct options *opt, int argc, char **argv)
 {
 	int o;
 	int val;
+        double val_f;
 	FILE *output, *urlfile;
 	char * line;
 	size_t len = 0;
 	ssize_t read;
 
-	while((o = getopt(argc, argv, "46Dhc:d:i:l:n:o:t:")) != -1) {
+	while((o = getopt(argc, argv, "46Dhc:d:i:l:n:o:t:r:")) != -1) {
 		switch(o) {
 		case '4':
 			opt->ai_family = AF_INET;
@@ -129,6 +131,14 @@ int parse_options(struct options *opt, int argc, char **argv)
 				opt->output = output;
 			}
 			break;
+                case 'r':
+                       val_f = atof(optarg);
+                       if (val_f < 0) {
+                                fprintf(stderr, "Invalid worker report interval value: %f\n", val_f);
+                                return -1;
+                       }
+                       opt->worker_report_interval = val_f;
+                       break;
 		case 't':
 			val = atoi(optarg);
 			if(val < 0) {

--- a/src/worker.c
+++ b/src/worker.c
@@ -125,14 +125,6 @@ static int init_worker(struct worker_data *data)
 
         /* Enable periodic worker reporting if enabled on CLI */
         if (data->worker_report_interval > 0) {
-                fprintf(stderr, "Enable reporting on write pipe fd: %d\n", data->pipe_w); 
-                if ((res = curl_easy_setopt(data->curl, CURLOPT_PROGRESSFUNCTION, old_prog_report)) != CURLE_OK) {
-                        fprintf(stderr, "cURL option error: %s\n", curl_easy_strerror(res));
-                } 
-                if ((res = curl_easy_setopt(data->curl, CURLOPT_PROGRESSDATA, data)) != CURLE_OK) {
-                        fprintf(stderr, "cURL option error: %s\n", curl_easy_strerror(res));
-                } 
-
 #if LIBCURL_VERSION_NUM >= 0x72000
                 if ((res = curl_easy_setopt(data->curl, CURLOPT_XFERINFOFUNCTION, prog_report)) != CURLE_OK) {
                         fprintf(stderr, "cURL option error: %s\n", curl_easy_strerror(res));
@@ -140,11 +132,18 @@ static int init_worker(struct worker_data *data)
                 if ((res = curl_easy_setopt(data->curl, CURLOPT_XFERINFODATA, data)) != CURLE_OK) {
                         fprintf(stderr, "cURL option error: %s\n", curl_easy_strerror(res));
                 } 
+#else 
+                if ((res = curl_easy_setopt(data->curl, CURLOPT_PROGRESSFUNCTION, old_prog_report)) != CURLE_OK) {
+                        fprintf(stderr, "cURL option error: %s\n", curl_easy_strerror(res));
+                } 
+                if ((res = curl_easy_setopt(data->curl, CURLOPT_PROGRESSDATA, data)) != CURLE_OK) {
+                        fprintf(stderr, "cURL option error: %s\n", curl_easy_strerror(res));
+                } 
 #endif
                 if ((res = curl_easy_setopt(data->curl, CURLOPT_NOPROGRESS, 0L)) != CURLE_OK) {
                         fprintf(stderr, "cURL option error: %s\n", curl_easy_strerror(res));
                 } 
-                data->last_dlnow = (curl_off_t)0;
+                data->last_dlnow = 0;
         } 
 
 
@@ -186,7 +185,6 @@ static int destroy_worker(struct worker_data *data)
 
 static int reset_worker(struct worker_data *data)
 {
-        fprintf(stderr, "RESET WORKER\n");
 	destroy_worker(data);
 	return init_worker(data);
 }


### PR DESCRIPTION
I'd like to be able to use flent to generate bandwidth graphs for http (much like netperf). This PR enhances http-getter to output netperf like interim bandwidth data from curl. 