### PR TITLE
Fix PKGBUILD

### DIFF
--- a/packaging/PKGBUILD
+++ b/packaging/PKGBUILD
@@ -9,7 +9,7 @@ pkgdesc="Parallel HTTP getter."
 arch=(x86_64)
 url="https://github.com/tohojo/http-getter"
 license=('GPL')
-depends=('glibc')
+depends=('curl')
 makedepends=('git' 'cmake')
 source=('git+http://github.com/tohojo/http-getter.git')
 md5sums=('SKIP')
@@ -28,8 +28,8 @@ build() {
 
 package() {
   cd $_gitname
-  mkdir -p "$pkgdir/bin/"
-  install -m 755 http-getter "$pkgdir/bin/"
+  mkdir -p "$pkgdir/usr/bin/"
+  install -m 755 http-getter "$pkgdir/usr/bin/"
 }
 
 # vim:set ts=2 sw=2 et:


### PR DESCRIPTION
As of pacman 4.2, pacman no longer resolve symlink: http://allanmcrae.com/2014/12/pacman-4-2-released/ , so running makepkg -si results in this error:
```
==> Installing package http-getter-git with pacman -U...
loading packages...
resolving dependencies...
looking for conflicting packages...

Packages (1) http-getter-git-20171203-1

Total Installed Size:  0.02 MiB

:: Proceed with installation? [Y/n] y
(1/1) checking keys in keyring                                                                                     [####################################################################] 100%
(1/1) checking package integrity                                                                                   [####################################################################] 100%
(1/1) loading package files                                                                                        [####################################################################] 100%
(1/1) checking for file conflicts                                                                                  [####################################################################] 100%
error: failed to commit transaction (conflicting files)
http-getter-git: /bin exists in filesystem
Errors occurred, no packages were upgraded.
==> WARNING: Failed to install built package(s).
```
as /bin is actually a symlink to /usr/bin.

Running the package through namcap also shows that 
```
feanor@silmaril ~/h/packaging> namcap http-getter-git-20171203-1-x86_64.pkg.tar.xz 
http-getter-git W: File (bin/) exists in a non-standard directory.
http-getter-git W: File (bin/http-getter) exists in a non-standard directory.
http-getter-git E: Dependency curl detected and not included (libraries ['usr/lib/libcurl.so.4'] needed in files ['bin/http-getter'])
```
so the depends array is changed from glibc to curl as curl depends to glibc anyway. Now this package passes namcap and can be installed