### PR TITLE
Fix compilation on macOS Nix clang

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -28,6 +28,11 @@ else()
   MESSAGE(SEND_ERROR "Could not find cURL on your system")
 ENDIF(CURL_FOUND)
 
+include(CheckCCompilerFlag)
+check_c_compiler_flag(-Werror=gnu-empty-initializer HAS_WERROR_GNU_EMPTY_INITIALIZER)
+if(HAS_WERROR_GNU_EMPTY_INITIALIZER)
+    set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Werror=gnu-empty-initializer")
+endif(HAS_WERROR_GNU_EMPTY_INITIALIZER)
 
 set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wall -Wno-long-long")
 

--- a/src/getter.c
+++ b/src/getter.c
@@ -14,7 +14,7 @@
 
 static int get_urls(struct worker *w, char **urls, char *urls_loc, int *total_bytes)
 {
-	char buf[PIPE_BUF+1] = {}, outbuf[PIPE_BUF+1] = {};
+	char buf[PIPE_BUF+1] = {0}, outbuf[PIPE_BUF+1] = {0};
 	int len, i, err;
 	size_t bytes = 0, urls_c = 0;
 	len = snprintf(outbuf, sizeof(outbuf)-1, "URLLIST %s", urls_loc);
@@ -52,7 +52,7 @@ int get_once(struct worker *workers, char **urls_opt, size_t urls_l, char *urls_
 	int cururl = 0, total_bytes = 0, urls_alloc = 0, reqs = 0, err = 0, bytes, nfds, retval, len, i;
 	char **urls = urls_opt;
 	fd_set rfds;
-	char buf[PIPE_BUF+1] = {}, outbuf[PIPE_BUF+1] = {};
+	char buf[PIPE_BUF+1] = {0}, outbuf[PIPE_BUF+1] = {0};
 	for(w = workers; w; w = w->next) {
 		if(msg_write(w->pipe_w, "RESET", sizeof("RESET")))
 			return -1;

--- a/src/main.c
+++ b/src/main.c
@@ -16,8 +16,6 @@ static struct options opt;
 
 static struct sigaction sigdfl = {
 	.sa_handler = SIG_DFL,
-	.sa_mask = {},
-	.sa_flags = 0,
 };
 
 static void sig_exit(int signal)
@@ -34,8 +32,6 @@ static void sig_exit(int signal)
 
 static struct sigaction sigact = {
 	.sa_handler = sig_exit,
-	.sa_mask = {},
-	.sa_flags = 0,
 };
 
 

--- a/src/worker.c
+++ b/src/worker.c
@@ -8,6 +8,7 @@
 #define _GNU_SOURCE
 #include <fcntl.h>
 #include <unistd.h>
+#include <signal.h>
 #include <stdlib.h>
 #include <string.h>
 #include <sys/types.h>
@@ -158,8 +159,8 @@ static int reset_worker(struct worker_data *data)
 
 static int run_worker(struct worker_data *data)
 {
-	char buf[PIPE_BUF+1] = {};
-	char outbuf[PIPE_BUF+1] = {};
+	char buf[PIPE_BUF+1] = {0};
+	char outbuf[PIPE_BUF+1] = {0};
 	char *urls[MAX_URLS];
 	size_t urls_c;
 	char *p;
@@ -230,14 +231,10 @@ static int run_worker(struct worker_data *data)
 
 static struct sigaction sigign = {
 	.sa_handler = SIG_IGN,
-	.sa_mask = {},
-	.sa_flags = 0,
 };
 
 static struct sigaction sigdfl = {
 	.sa_handler = SIG_DFL,
-	.sa_mask = {},
-	.sa_flags = 0,
 };
 
 
@@ -261,7 +258,7 @@ int start_worker(struct worker *w, struct options *opt)
 		return EXIT_FAILURE;
 	}
 	if(cpid == 0) {
-		struct worker_data wd = {};
+		struct worker_data wd = {0};
 		wd.pipe_r = fds_w[0];
 		wd.pipe_w = fds_r[1];
 		wd.debug = opt->debug;


### PR DESCRIPTION
Fixes 'error: scalar initializer cannot be empty'

Relevant build failure: https://hydra.nixos.org/build/127472341/nixlog/1
<details>

```
unpacking sources
unpacking source archive /nix/store/b58z2v8l0qww765863qgw8fhn8h75zsw-source
source root is source
patching sources
configuring
fixing cmake files...
cmake flags: -DCMAKE_FIND_USE_SYSTEM_PACKAGE_REGISTRY=OFF -DCMAKE_FIND_USE_PACKAGE_REGISTRY=OFF -DCMAKE_EXPORT_NO_PACKAGE_REGISTRY=ON -DCMAKE_BUILD_TYPE=Release -DCMAKE_SKIP_BUILD_RPATH=ON -DBUILD_TESTING=OFF -DCMAKE_INSTALL_LOCALEDIR=/nix/store/pcd637av2y3rp05wh34i9x2x112rm9nl-http-getter-unstable-2018-06-06/share/locale -DCMAKE_INSTALL_LIBEXECDIR=/nix/store/pcd637av2y3rp05wh34i9x2x112rm9nl-http-getter-unstable-2018-06-06/libexec -DCMAKE_INSTALL_LIBDIR=/nix/store/pcd637av2y3rp05wh34i9x2x112rm9nl-http-getter-unstable-2018-06-06/lib -DCMAKE_INSTALL_DOCDIR=/nix/store/pcd637av2y3rp05wh34i9x2x112rm9nl-http-getter-unstable-2018-06-06/share/doc/http-getter -DCMAKE_INSTALL_INFODIR=/nix/store/pcd637av2y3rp05wh34i9x2x112rm9nl-http-getter-unstable-2018-06-06/share/info -DCMAKE_INSTALL_MANDIR=/nix/store/pcd637av2y3rp05wh34i9x2x112rm9nl-http-getter-unstable-2018-06-06/share/man -DCMAKE_INSTALL_OLDINCLUDEDIR=/nix/store/pcd637av2y3rp05wh34i9x2x112rm9nl-http-getter-unstable-2018-06-06/include -DCMAKE_INSTALL_INCLUDEDIR=/nix/store/pcd637av2y3rp05wh34i9x2x112rm9nl-http-getter-unstable-2018-06-06/include -DCMAKE_INSTALL_SBINDIR=/nix/store/pcd637av2y3rp05wh34i9x2x112rm9nl-http-getter-unstable-2018-06-06/sbin -DCMAKE_INSTALL_BINDIR=/nix/store/pcd637av2y3rp05wh34i9x2x112rm9nl-http-getter-unstable-2018-06-06/bin -DCMAKE_INSTALL_NAME_DIR=/nix/store/pcd637av2y3rp05wh34i9x2x112rm9nl-http-getter-unstable-2018-06-06/lib -DCMAKE_POLICY_DEFAULT_CMP0025=NEW -DCMAKE_OSX_SYSROOT= -DCMAKE_OSX_ARCHITECTURES=x86_64 -DCMAKE_FIND_FRAMEWORK=LAST -DCMAKE_STRIP=/nix/store/qmxmk9l5ldy8zp50qaxmyv2r1sdfw7az-cctools-binutils-darwin-927.0.2/bin/strip -DCMAKE_RANLIB=/nix/store/qmxmk9l5ldy8zp50qaxmyv2r1sdfw7az-cctools-binutils-darwin-927.0.2/bin/ranlib -DCMAKE_AR=/nix/store/qmxmk9l5ldy8zp50qaxmyv2r1sdfw7az-cctools-binutils-darwin-927.0.2/bin/ar -DCMAKE_C_COMPILER=clang -DCMAKE_CXX_COMPILER=clang++ -DCMAKE_INSTALL_PREFIX=/nix/store/pcd637av2y3rp05wh34i9x2x112rm9nl-http-getter-unstable-2018-06-06  
-- The C compiler identification is Clang 7.1.0
-- The CXX compiler identification is Clang 7.1.0
-- Detecting C compiler ABI info
-- Detecting C compiler ABI info - done
-- Check for working C compiler: /nix/store/sw7b2gcklaj3iy5ikv7ag163bpry3ivb-clang-wrapper-7.1.0/bin/clang - skipped
-- Detecting C compile features
-- Detecting C compile features - done
-- Detecting CXX compiler ABI info
-- Detecting CXX compiler ABI info - done
-- Check for working CXX compiler: /nix/store/sw7b2gcklaj3iy5ikv7ag163bpry3ivb-clang-wrapper-7.1.0/bin/clang++ - skipped
-- Detecting CXX compile features
-- Detecting CXX compile features - done
-- Found CURL: /nix/store/6mcy93jb45gclkqhlvf9ksg5azkjmi5x-curl-7.72.0/lib/libcurl.dylib (found version "7.72.0")  
-- Curl libraries found at: /nix/store/6mcy93jb45gclkqhlvf9ksg5azkjmi5x-curl-7.72.0/lib/libcurl.dylib
-- Curl includes found at: /nix/store/yiwzjs8qki9kvgrr7d7gbslqz50yjmh4-curl-7.72.0-dev/include
-- Configuring done
-- Generating done
CMake Warning:
  Manually-specified variables were not used by the project:

    BUILD_TESTING
    CMAKE_EXPORT_NO_PACKAGE_REGISTRY
    CMAKE_INSTALL_BINDIR
    CMAKE_INSTALL_DOCDIR
    CMAKE_INSTALL_INCLUDEDIR
    CMAKE_INSTALL_INFODIR
    CMAKE_INSTALL_LIBDIR
    CMAKE_INSTALL_LIBEXECDIR
    CMAKE_INSTALL_LOCALEDIR
    CMAKE_INSTALL_MANDIR
    CMAKE_INSTALL_OLDINCLUDEDIR
    CMAKE_INSTALL_SBINDIR


-- Build files have been written to: /tmp/nix-build-http-getter-unstable-2018-06-06.drv-0/source/build
cmake: enabled parallel building
building
build flags: -j1 -l1 SHELL=/nix/store/smimdn17mp2ih6nfxwl78mswwdkmcm56-bash-4.4-p23/bin/bash
Scanning dependencies of target http-getter
[ 16%] Building C object CMakeFiles/http-getter.dir/src/main.c.o
/tmp/nix-build-http-getter-unstable-2018-06-06.drv-0/source/src/main.c:19:13: error: scalar initializer cannot be empty
        .sa_mask = {},
                   ^~
/tmp/nix-build-http-getter-unstable-2018-06-06.drv-0/source/src/main.c:37:13: error: scalar initializer cannot be empty
        .sa_mask = {},
                   ^~
2 errors generated.
make[2]: *** [CMakeFiles/http-getter.dir/build.make:82: CMakeFiles/http-getter.dir/src/main.c.o] Error 1
make[1]: *** [CMakeFiles/Makefile2:95: CMakeFiles/http-getter.dir/all] Error 2
make: *** [Makefile:171: all] Error 2
builder for '/nix/store/7q3b9ipzra2qz0d4cvm59byl5fh2ncdl-http-getter-unstable-2018-06-06.drv' failed with exit code 2
```
</details>

The '= {}' empty initializer is a GNU extension, not supported on older
versions of clang. For arrays, we can use '= {0}' to ensure they are
zero-initialized. When using a designated initializer, unspecified
members are zero-initialized, so we can simply omit them.

An alternative approach would be to zero-initialize struct members via the
universal initializer '= {0}'. However, this causes spurious warnings on GCC.
See e.g. https://gcc.gnu.org/bugzilla/show_bug.cgi?id=53119 and linked issues.

To prevent regressions, recent clang can warn on these with
-Wgnu-empty-initializer, so this is enabled if supported.
However, GNU would need -Wpedantic to do the same.